### PR TITLE
pipeline now uses docker login because of docker pull limitations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,25 @@ executors:
   dotnet-core-sdk:
     docker:
     - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      auth:
+        username: $DOCKER_LOGIN
+        password: $DOCKER_ACCESSTOKEN
   docker-publisher:
     environment:
       IMAGE_NAME: openftth/gdb-integrator
     docker:
       - image: cimg/base:2020.09
+        auth:
+          username: $DOCKER_LOGIN
+          password: $DOCKER_ACCESSTOKEN
   alpine-git:
     environment:
       IMAGE_NAME: openftth/gdb-integrator
     docker:
     - image: alpine/git
+      auth:
+        username: $DOCKER_LOGIN
+        password: $DOCKER_ACCESSTOKEN
 
 jobs:
   build-app:
@@ -115,14 +124,17 @@ workflows:
   build-test-upload_image:
     jobs:
       - build-app:
+          context: docker
           filters:
             tags:
               only: /.*/
       - test-app:
+          context: docker
           filters:
             tags:
               only: /.*/
       - build-docker-image:
+          context: docker
           filters:
             tags:
               only: /^v.*/
@@ -140,6 +152,7 @@ workflows:
             branches:
               ignore: /.*/
       - update-helm-chart:
+          context: docker
           requires:
            - docker-publish-image
           filters:


### PR DESCRIPTION
Updates circleci-pipeline to use docker login.

---

On November 1st, Docker Hub will begin limiting anonymous image pulls. We want to make sure you know how you might be impacted and what you can do to avoid interruptions to your workflow.

Adding Docker authentication to your pipeline config is the easiest way to avoid any service disruptions. If you use the Docker executor or pull Docker images when using the machine executor on CircleCI, we encourage you to authenticate. Because the anonymous API rate limits are based on IP addresses, they will impact CircleCI cloud customers. Authenticated users get higher per-user rate limits, regardless of IP. 