### PR TITLE
sets minimum batch size to 1

### DIFF
--- a/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Postgres/PostgresRouteNetworkSubscriber.cs
+++ b/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Postgres/PostgresRouteNetworkSubscriber.cs
@@ -39,6 +39,7 @@ namespace OpenFTTH.GDBIntegrator.Subscriber.Kafka.Postgres
                 .Topics(t => t.Subscribe(_kafkaSetting.PostgisRouteNetworkTopic))
                 .Positions(p => p.StoreInFileSystem(_kafkaSetting.PositionFilePath))
                 .Logging(l => l.UseSerilog())
+                .Options(x => x.SetMinimumBatchSize(1))
                 .Handle(async (messages, context, token) =>
                 {
                     foreach (var message in messages)


### PR DESCRIPTION
Set the minimum batch size to 1 to increase performance on single messages.