### PR TITLE
emit events on tmp_event_name updated

### DIFF
--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeInfoCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeInfoCommandFactory.cs
@@ -29,27 +29,27 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
                     $"Parameter {nameof(before)} or {nameof(after)} cannot be null");
             }
 
-            if (IsRouteNodeInfoUpdated(before, after))
+            if (after.TmpEventName?.ToLower() == "RouteNodeInfoUpdated".ToLower() || IsRouteNodeInfoUpdated(before, after))
             {
                 notifications.Add(new RouteNodeInfoUpdated(after));
             }
 
-            if (IsLifecycleInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "LifecycleInfoUpdated".ToLower() || IsLifecycleInfoModified(before, after))
             {
                 notifications.Add(new RouteNodeLifecycleInfoUpdated(after));
             }
 
-            if (IsMappingInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "MappingInfoUpdated".ToLower() || IsMappingInfoModified(before, after))
             {
                 notifications.Add(new RouteNodeMappingInfoUpdated(after));
             }
 
-            if (IsNamingInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "NamingInfoUpdated".ToLower() || IsNamingInfoModified(before, after))
             {
                 notifications.Add(new RouteNodeNamingInfoUpdated(after));
             }
 
-            if (IsSafetyInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "SafetyInfoUpdated".ToLower() || IsSafetyInfoModified(before, after))
             {
                 notifications.Add(new RouteNodeSafetyInfoUpdated(after));
             }

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
@@ -28,27 +28,27 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
                     $"Parameter {nameof(before)} or {nameof(after)} cannot be null");
             }
 
-            if (IsRouteSegmentInfoUpdated(before, after))
+            if (after.TmpEventName?.ToLower() == "RouteSegmentInfoUpdated".ToLower() || IsRouteSegmentInfoUpdated(before, after))
             {
                 notifications.Add(new RouteSegmentInfoUpdated(after));
             }
 
-            if (IsLifecycleInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "LifeCycleInfoUpdated".ToLower() || IsLifecycleInfoModified(before, after))
             {
                 notifications.Add(new RouteSegmentLifecycleInfoUpdated(after));
             }
 
-            if (IsMappingInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "MappingInfoUpdated".ToLower() || IsMappingInfoModified(before, after))
             {
                 notifications.Add(new RouteSegmentMappingInfoUpdated(after));
             }
 
-            if (IsNamingInfoModified(before, after))
+            if (after.TmpEventName?.ToLower() == "NamingInfoUpdated".ToLower() || IsNamingInfoModified(before, after))
             {
                 notifications.Add(new RouteSegmentNamingInfoUpdated(after));
             }
 
-            if (IsSafetyInfoModified(before, after))
+            if (after.TmpEventName?.ToString() == "SafetyInfoUpdated".ToLower() || IsSafetyInfoModified(before, after))
             {
                 notifications.Add(new RouteSegmentSafetyInfoUpdated(after));
             }

--- a/src/OpenFTTH.GDBIntegrator.RouteNetwork/RouteNode.cs
+++ b/src/OpenFTTH.GDBIntegrator.RouteNetwork/RouteNode.cs
@@ -24,9 +24,11 @@ namespace OpenFTTH.GDBIntegrator.RouteNetwork
         public SafetyInfo SafetyInfo { get; set; }
         public RouteNodeInfo RouteNodeInfo { get; set; }
         public NamingInfo NamingInfo { get; set; }
+        // TODO remove
+        public string TmpEventName { get; set; }
 
         // Default constructor is needed for serialization
-        public RouteNode() {}
+        public RouteNode() { }
 
         public RouteNode(Guid mrid, byte[] coord, Guid workTaskMrid, string username, string applicationName)
         {

--- a/src/OpenFTTH.GDBIntegrator.RouteNetwork/RouteSegment.cs
+++ b/src/OpenFTTH.GDBIntegrator.RouteNetwork/RouteSegment.cs
@@ -25,6 +25,9 @@ namespace OpenFTTH.GDBIntegrator.RouteNetwork
         public RouteSegmentInfo RouteSegmentInfo { get; set; }
         public NamingInfo NamingInfo { get; set; }
 
+        // TODO remove
+        public string TmpEventName { get; set; }
+
         public virtual Point FindStartPoint()
         {
             var lineString = GetLineString();

--- a/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Serialize/RouteNetworkSerializer.cs
+++ b/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Serialize/RouteNetworkSerializer.cs
@@ -94,6 +94,10 @@ namespace OpenFTTH.GDBIntegrator.Subscriber.Kafka.Serialize
                 MarkAsDeleted = (bool)routeSegment.marked_to_be_deleted,
                 ApplicationInfo = routeSegment.application_info.ToString(),
                 DeleteMe = (bool)routeSegment.delete_me,
+
+                // TODO remove
+                TmpEventName = routeSegment.tmp_event_name.ToString(),
+
                 LifeCycleInfo = new LifecycleInfo(
                      _infoMapper.MapDeploymentState((string)routeSegment.lifecycle_deployment_state),
                      (DateTime?)routeSegment.lifecycle_installation_date,
@@ -157,6 +161,10 @@ namespace OpenFTTH.GDBIntegrator.Subscriber.Kafka.Serialize
                 Mrid = new Guid(routeNode.mrid.ToString()),
                 Username = routeNode.user_name.ToString(),
                 WorkTaskMrid = routeNode.work_task_mrid.ToString() == string.Empty ? System.Guid.Empty : new Guid(routeNode.work_task_mrid.ToString()),
+
+                // TODO remove
+                TmpEventName = routeNode.tmp_event_name.ToString(),
+
                 LifeCycleInfo = new LifecycleInfo(
                     _infoMapper.MapDeploymentState((string)routeNode.lifecycle_deployment_state),
                     (DateTime?)routeNode.lifecycle_installation_date,

--- a/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Serialize/RouteNetworkSerializer.cs
+++ b/src/OpenFTTH.GDBIntegrator.Subscriber/Kafka/Serialize/RouteNetworkSerializer.cs
@@ -96,7 +96,7 @@ namespace OpenFTTH.GDBIntegrator.Subscriber.Kafka.Serialize
                 DeleteMe = (bool)routeSegment.delete_me,
 
                 // TODO remove
-                TmpEventName = routeSegment.tmp_event_name.ToString(),
+                TmpEventName = routeSegment.tmp_event_name.ToString() == string.Empty ? null : routeSegment.tmp_event_name.ToString(),
 
                 LifeCycleInfo = new LifecycleInfo(
                      _infoMapper.MapDeploymentState((string)routeSegment.lifecycle_deployment_state),
@@ -163,7 +163,7 @@ namespace OpenFTTH.GDBIntegrator.Subscriber.Kafka.Serialize
                 WorkTaskMrid = routeNode.work_task_mrid.ToString() == string.Empty ? System.Guid.Empty : new Guid(routeNode.work_task_mrid.ToString()),
 
                 // TODO remove
-                TmpEventName = routeNode.tmp_event_name.ToString(),
+                TmpEventName = routeNode.tmp_event_name.ToString() == string.Empty ? null : routeNode.tmp_event_name.ToString(),
 
                 LifeCycleInfo = new LifecycleInfo(
                     _infoMapper.MapDeploymentState((string)routeNode.lifecycle_deployment_state),

--- a/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteNodeSerializerMessage.json
+++ b/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteNodeSerializerMessage.json
@@ -286,7 +286,8 @@
       "work_task_mrid": null,
       "user_name": null,
       "application_name": null,
-      "application_info": null
+      "application_info": null,
+      "tmp_event_name": null
     },
     "after": {
       "mrid": "9bffa519-c672-49fd-93d0-52cd22519346",
@@ -307,7 +308,8 @@
       "lifecycle_installation_date": "2020-08-12T00:00:00Z",
       "lifecycle_removal_date": "2020-08-12T00:00:00Z",
       "routenode_kind": "",
-      "routenode_function": "FlexPoint"
+      "routenode_function": "FlexPoint",
+      "tmp_event_name": null
     },
     "source": {
       "version": "1.1.2.Final",

--- a/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteNodeSerializerMessageBeforeIsNull.json
+++ b/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteNodeSerializerMessageBeforeIsNull.json
@@ -420,7 +420,8 @@
       "routenode_kind": "CabinetBig",
       "routenode_function": "FlexPoint",
       "naming_name": "AB13",
-      "naming_description": "AB13 desc"
+      "naming_description": "AB13 desc",
+      "tmp_event_name": null
     },
     "source": {
       "version": "1.1.2.Final",

--- a/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessage.json
+++ b/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessage.json
@@ -264,7 +264,8 @@
       "work_task_mrid": null,
       "user_name": null,
       "application_name": null,
-      "application_info": null
+      "application_info": null,
+      "tmp_event_name": null
     },
     "after": {
       "mrid": "57fb87f5-093c-405d-b619-755e3f39073f",
@@ -278,7 +279,8 @@
       "work_task_mrid": null,
       "user_name": null,
       "application_name": null,
-      "application_info": null
+      "application_info": null,
+      "tmp_event_name": null
     },
     "source": {
       "version": "1.1.2.Final",

--- a/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessageBeforeIsNull.json
+++ b/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessageBeforeIsNull.json
@@ -279,7 +279,8 @@
       "routesegment_width": "20m",
       "routesegment_height": "10m",
       "naming_name": "AB13",
-      "naming_description": "AB13 desc"
+      "naming_description": "AB13 desc",
+      "tmp_event_name": null
     },
     "source": {
       "version": "1.1.2.Final",

--- a/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessageCoordIsNull.json
+++ b/test/OpenFTTH.GDBIntegrator.Subscriber.Tests/TestData/RouteSegmentSerializerMessageCoordIsNull.json
@@ -264,7 +264,8 @@
       "work_task_mrid": null,
       "user_name": null,
       "application_name": null,
-      "application_info": null
+      "application_info": null,
+      "tmp_event_name": null
     },
     "after": {
       "mrid": "57fb87f5-093c-405d-b619-755e3f39073f",
@@ -275,7 +276,8 @@
       "work_task_mrid": null,
       "user_name": null,
       "application_name": null,
-      "application_info": null
+      "application_info": null,
+      "tmp_event_name": null
     },
     "source": {
       "version": "1.1.2.Final",


### PR DESCRIPTION
To handle future requirements where all infos needs to be emitted on our kafka topic, we have to support previously updated infos. To do this we implement a temporary fix that can find and emit all previous events.