### PR TITLE
now rollbacks on updates on deleted network features

### DIFF
--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
@@ -8,7 +8,7 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase
     public interface IGeoDatabase
     {
         Task<RouteNode> GetRouteNodeShadowTable(Guid mrid);
-        Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool getDeletedSegments = false);
+        Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool includeDeleted = false);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(RouteSegment routeSegment);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(byte[] coord);
         Task<List<RouteNode>> GetIntersectingEndRouteNodes(RouteSegment routeSegment);

--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
@@ -7,7 +7,7 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase
 {
     public interface IGeoDatabase
     {
-        Task<RouteNode> GetRouteNodeShadowTable(Guid mrid);
+        Task<RouteNode> GetRouteNodeShadowTable(Guid mrid, bool includeDeleted = false);
         Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool includeDeleted = false);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(RouteSegment routeSegment);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(byte[] coord);

--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
@@ -8,7 +8,7 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase
     public interface IGeoDatabase
     {
         Task<RouteNode> GetRouteNodeShadowTable(Guid mrid);
-        Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid);
+        Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool getDeletedSegments = false);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(RouteSegment routeSegment);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(byte[] coord);
         Task<List<RouteNode>> GetIntersectingEndRouteNodes(RouteSegment routeSegment);

--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/Postgres/Postgis.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/Postgres/Postgis.cs
@@ -69,7 +69,7 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase.Postgres
             return routeNode.FirstOrDefault();
         }
 
-        public async Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool getDeletedRouteSegments = false)
+        public async Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool includeDeleted = false)
         {
             var connection = GetNpgsqlConnection();
             var query = @"SELECT
@@ -94,9 +94,14 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase.Postgres
                     routesegment_width AS routeSegmentWidth,
                     safety_classification AS safetyClassification,
                     safety_remark AS safetyRemark
-                    FROM route_network_integrator.route_segment WHERE mrid = @mrid AND marked_to_be_deleted = @getDeletedRouteSegments";
+                    FROM route_network_integrator.route_segment";
 
-            var routeSegment = await connection.QueryAsync<RouteSegment>(query, new { mrid, getDeletedRouteSegments });
+            if (!includeDeleted)
+            {
+                query += " WHERE mrid = @mrid AND marked_to_be_deleted = false";
+            }
+
+            var routeSegment = await connection.QueryAsync<RouteSegment>(query, new { mrid });
 
             return routeSegment.FirstOrDefault();
         }

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeCommandFactory.cs
@@ -102,7 +102,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
                 return notifications;
             }
 
-            return new List<INotification> { new InvalidRouteNodeOperation { RouteNode = routeNode } };
+            return new List<INotification> { new InvalidRouteNodeOperation { RouteNode = routeNode, Message = "Route node did not fit any condition in command factory." } };
         }
 
         private async Task<bool> IsValidNodeUpdate(RouteNode before, RouteNode after)

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
@@ -140,7 +140,8 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
                 && !IsNamingInfoModified(after, shadowTableRouteSegment)
                 && !IsMappingInfoModified(after, shadowTableRouteSegment)
                 && !IsLifecycleInfoModified(after, shadowTableRouteSegment)
-                && !IsRouteSegmentInfoModified(after, shadowTableRouteSegment);
+                && !IsRouteSegmentInfoModified(after, shadowTableRouteSegment)
+                && !IsSafetyInfoModified(after, shadowTableRouteSegment);
         }
     }
 }

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentInfoCommandFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,11 +23,25 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
 
             if (before is null || after is null)
             {
-                throw new ArgumentNullException(
-                    $"Parameter {nameof(before)} or {nameof(after)} cannot be null");
+                notifications.Add(new RollbackInvalidRouteSegment(before));
+                return notifications;
             }
 
-            if (IsRouteSegmentInfoUpdated(before, after))
+            var routeSegmentShadowTable = await _geoDatabase.GetRouteSegmentShadowTable(after.Mrid, true);
+
+            if (AlreadyUpdated(after, routeSegmentShadowTable))
+            {
+                notifications.Add(new DoNothing($"{nameof(RouteSegment)} is already updated, therefore do nothing."));
+                return notifications;
+            }
+
+            if (before.MarkAsDeleted)
+            {
+                notifications.Add(new RollbackInvalidRouteSegment(before));
+                return notifications;
+            }
+
+            if (IsRouteSegmentInfoModified(before, after))
             {
                 notifications.Add(new RouteSegmentInfoUpdated(after));
             }
@@ -61,7 +74,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
             return notifications;
         }
 
-        private bool IsRouteSegmentInfoUpdated(RouteSegment before, RouteSegment after)
+        private bool IsRouteSegmentInfoModified(RouteSegment before, RouteSegment after)
         {
             if (before.RouteSegmentInfo?.Height != after.RouteSegmentInfo?.Height ||
                 before.RouteSegmentInfo?.Kind != after.RouteSegmentInfo?.Kind ||
@@ -119,6 +132,15 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
             }
 
             return false;
+        }
+
+        private bool AlreadyUpdated(RouteSegment after, RouteSegment shadowTableRouteSegment)
+        {
+            return !IsNamingInfoModified(after, shadowTableRouteSegment)
+                && !IsNamingInfoModified(after, shadowTableRouteSegment)
+                && !IsMappingInfoModified(after, shadowTableRouteSegment)
+                && !IsLifecycleInfoModified(after, shadowTableRouteSegment)
+                && !IsRouteSegmentInfoModified(after, shadowTableRouteSegment);
         }
     }
 }

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeCommandFactoryTest.cs
@@ -210,7 +210,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
 
             A.CallTo(() => afterNode.Mrid).Returns(Guid.NewGuid());
 
-            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid))
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid, false))
                 .Returns(integratorRouteNode);
 
             A.CallTo(() => afterNode.GetGeoJsonCoordinate())
@@ -280,7 +280,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             RouteNode shadowTableRouteNode = null;
 
             A.CallTo(() => afterNode.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid)).Returns(shadowTableRouteNode);
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid, false)).Returns(shadowTableRouteNode);
 
             var factory = new RouteNodeCommandFactory(applicationSetting, geoDatabase);
 
@@ -299,7 +299,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var shadowTableRouteNode = A.Fake<RouteNode>();
 
             A.CallTo(() => afterNode.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid)).Returns(shadowTableRouteNode);
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid, false)).Returns(shadowTableRouteNode);
 
             A.CallTo(() => afterNode.GetGeoJsonCoordinate())
                 .Returns("[665931.4446905176,7197297.75114815]");
@@ -338,7 +338,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var shadowTableRouteNode = A.Fake<RouteNode>();
 
             A.CallTo(() => afterNode.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid)).Returns(shadowTableRouteNode);
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(afterNode.Mrid, false)).Returns(shadowTableRouteNode);
 
             A.CallTo(() => afterNode.GetGeoJsonCoordinate())
                 .Returns("[665931.4446905176,7197297.75114815]");

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeInfoCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeInfoCommandFactoryTest.cs
@@ -17,25 +17,123 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
     public class RouteNodeInfoCommandFactoryTest
     {
         [Fact]
-        public async Task Create_ShouldThrowException_OnNodeAfterOrBeforeBeingNull()
+        public async Task Create_ShouldReturnRollBackInvalidRouteNode_OnAfterBeingNull()
         {
             var geoDatabase = A.Fake<IGeoDatabase>();
+            var before = new RouteNode();
+            RouteNode after = null;
+
             var factory = new RouteNodeInfoCommandFactory(geoDatabase);
+            var result = await factory.Create(before, after);
 
-            // Both being null
-            Func<Task> actOne = async () =>
-                await factory.Create(null, null);
-            await actOne.Should().ThrowExactlyAsync<ArgumentNullException>();
+            var rollbackEvent = (RollbackInvalidRouteNode)result.First();
 
-            // Before being null
-            Func<Task> actTwo = async () =>
-                await factory.Create(null, new RouteNode());
-            await actTwo.Should().ThrowExactlyAsync<ArgumentNullException>();
+            using (var scope = new AssertionScope())
+            {
+                result.Count().Should().Be(1);
+                rollbackEvent.Should().BeOfType(typeof(RollbackInvalidRouteNode));
+            }
+        }
 
-            // After being null
-            Func<Task> actThree = async () =>
-                await factory.Create(new RouteNode(), null);
-            await actThree.Should().ThrowExactlyAsync<ArgumentNullException>();
+        [Fact]
+        public async Task Create_ShouldReturnRollBackInvalidRouteNode_OnBeforeBeingNull()
+        {
+            var geoDatabase = A.Fake<IGeoDatabase>();
+            RouteNode before = null;
+            RouteNode after = new RouteNode();
+
+            var factory = new RouteNodeInfoCommandFactory(geoDatabase);
+            var result = await factory.Create(before, after);
+
+            var rollbackEvent = (RollbackInvalidRouteNode)result.First();
+
+            using (var scope = new AssertionScope())
+            {
+                result.Count().Should().Be(1);
+                rollbackEvent.Should().BeOfType(typeof(RollbackInvalidRouteNode));
+            }
+        }
+
+        [Fact]
+        public async Task Create_ShouldReturnDoNothing_OnShadowTableRouteNodeBeingEqToAfter()
+        {
+            var routeNodeId = Guid.NewGuid();
+            var geoDatabase = A.Fake<IGeoDatabase>();
+            var before = new RouteNode
+            {
+                Mrid = routeNodeId,
+                RouteNodeInfo = new RouteNodeInfo
+                {
+                    Kind = RouteNodeKindEnum.CabinetBig
+                }
+            };
+            var after = new RouteNode
+            {
+                Mrid = routeNodeId,
+                RouteNodeInfo = new RouteNodeInfo
+                {
+                    Kind = RouteNodeKindEnum.CabinetBig
+                }
+            };
+            var shadowTableSegment = new RouteNode
+            {
+                Mrid = routeNodeId,
+                RouteNodeInfo = new RouteNodeInfo
+                {
+                    Kind = RouteNodeKindEnum.CabinetBig
+                }
+            };
+
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(after.Mrid, true)).Returns(shadowTableSegment);
+
+            var factory = new RouteNodeInfoCommandFactory(geoDatabase);
+            var result = await factory.Create(before, after);
+
+            var doNothingEvent = (DoNothing)result.First();
+
+            using (var scope = new AssertionScope())
+            {
+                result.Count().Should().Be(1);
+                doNothingEvent.Should().BeOfType(typeof(DoNothing));
+            }
+        }
+
+        [Fact]
+        public async Task Create_ShouldRollback_OnBeforeBeingMarkedAsDeleted()
+        {
+            var routeNodeId = Guid.NewGuid();
+            var geoDatabase = A.Fake<IGeoDatabase>();
+            var before = new RouteNode
+            {
+                Mrid = routeNodeId,
+                MarkAsDeleted = true
+            };
+            var after = new RouteNode
+            {
+                Mrid = routeNodeId,
+                RouteNodeInfo = new RouteNodeInfo
+                {
+                    Kind = RouteNodeKindEnum.CabinetBig
+                }
+            };
+            var shadowTableSegment = new RouteNode
+            {
+                Mrid = routeNodeId,
+                MarkAsDeleted = true
+            };
+
+            A.CallTo(() => geoDatabase.GetRouteNodeShadowTable(after.Mrid, true)).Returns(shadowTableSegment);
+
+            var factory = new RouteNodeInfoCommandFactory(geoDatabase);
+            var result = await factory.Create(before, after);
+
+            var rollbackInvalidRouteSegment = (RollbackInvalidRouteNode)result.First();
+
+            using (var scope = new AssertionScope())
+            {
+                result.Count().Should().Be(1);
+                rollbackInvalidRouteSegment.Should().BeOfType(typeof(RollbackInvalidRouteNode));
+            }
         }
 
         [Fact]

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentCommandFactoryTest.cs
@@ -517,7 +517,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
 
             A.CallTo(() => routeSegmentAfter.Mrid).Returns(Guid.NewGuid());
             A.CallTo(() => routeSegmentShadowTable.Mrid).Returns(routeSegmentAfter.Mrid);
-            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid)).Returns(routeSegmentShadowTable);
+            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid, false)).Returns(routeSegmentShadowTable);
             A.CallTo(() => routeSegmentAfter.GetGeoJsonCoordinate()).Returns("LINESTRING(578223.64355838 6179284.23759438, 578238.4182511 6179279.78494725)");
             A.CallTo(() => routeSegmentShadowTable.GetGeoJsonCoordinate()).Returns("LINESTRING(578223.64355838 6179284.23759438, 578238.4182511 6179279.78494725)");
             A.CallTo(() => routeSegmentShadowTable.MarkAsDeleted).Returns(false);
@@ -542,7 +542,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var routeSegmentShadowTable = A.Fake<RouteSegment>();
 
             A.CallTo(() => routeSegmentAfter.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid)).Returns(routeSegmentShadowTable);
+            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid, false)).Returns(routeSegmentShadowTable);
             A.CallTo(() => routeSegmentShadowTable.Mrid).Returns(routeSegmentAfter.Mrid);
             A.CallTo(() => routeSegmentAfter.GetLineString()).Returns(A.Fake<LineString>());
 
@@ -573,7 +573,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var routeSegmentAfter = A.Fake<RouteSegment>();
             RouteSegment routeSegmentShadowTable = null;
 
-            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid)).Returns(routeSegmentShadowTable);
+            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid, false)).Returns(routeSegmentShadowTable);
 
             var factory = new RouteSegmentCommandFactory(applicationSettings, routeSegmentValidator, geoDatabase, routeNodeFactory);
 
@@ -594,7 +594,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var routeSegmentShadowTable = A.Fake<RouteSegment>();
 
             A.CallTo(() => routeSegmentAfter.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid)).Returns(routeSegmentShadowTable);
+            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid, false)).Returns(routeSegmentShadowTable);
             A.CallTo(() => routeSegmentShadowTable.Mrid).Returns(routeSegmentAfter.Mrid);
             A.CallTo(() => routeSegmentAfter.GetLineString()).Returns(A.Fake<LineString>());
 
@@ -639,7 +639,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var previousEndNode = A.Fake<RouteNode>();
 
             A.CallTo(() => routeSegmentAfter.Mrid).Returns(Guid.NewGuid());
-            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid)).Returns(routeSegmentShadowTable);
+            A.CallTo(() => geoDatabase.GetRouteSegmentShadowTable(routeSegmentAfter.Mrid, false)).Returns(routeSegmentShadowTable);
             A.CallTo(() => routeSegmentShadowTable.Mrid).Returns(routeSegmentAfter.Mrid);
             A.CallTo(() => routeSegmentAfter.GetLineString()).Returns(A.Fake<LineString>());
 

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentInfoCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentInfoCommandFactoryTest.cs
@@ -16,28 +16,6 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
     public class RouteSegmentInfoCommandFactoryTest
     {
         [Fact]
-        public async Task Create_ShouldThrowException_OnSegmentAfterOrBeforeBeingNull()
-        {
-            var geoDatabase = A.Fake<IGeoDatabase>();
-            var factory = new RouteSegmentInfoCommandFactory(geoDatabase);
-
-            // Both being null
-            Func<Task> actOne = async () =>
-                await factory.Create(null, null);
-            await actOne.Should().ThrowExactlyAsync<ArgumentNullException>();
-
-            // Before being null
-            Func<Task> actTwo = async () =>
-                await factory.Create(null, new RouteSegment());
-            await actTwo.Should().ThrowExactlyAsync<ArgumentNullException>();
-
-            // After being null
-            Func<Task> actThree = async () =>
-                await factory.Create(new RouteSegment(), null);
-            await actThree.Should().ThrowExactlyAsync<ArgumentNullException>();
-        }
-
-        [Fact]
         public async Task Create_ShouldReturnRouteSegmentInfoUpdated_OnUpdatedSegmentInfo()
         {
             var geoDatabase = A.Fake<IGeoDatabase>();


### PR DESCRIPTION
This update now rollbacks in case of RouteNode/RouteSegment infos being updated on a route-network element that is marked to be deleted.