### PR TITLE
now uses shadow nodes for command creation instead of before

### DIFF
--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteNodeCommandFactory.cs
@@ -29,7 +29,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
             if (before is null || after is null)
                 throw new ArgumentNullException($"Parameter {nameof(before)} or {nameof(after)} cannot both be null doing an update.");
 
-            var shadowTableNode = await _geoDatabase.GetRouteNodeShadowTable(after.Mrid);
+            var shadowTableNode = await _geoDatabase.GetRouteNodeShadowTable(after.Mrid, false);
 
             if (shadowTableNode is null)
                 return new List<INotification> { new DoNothing($"{nameof(RouteNode)} is already deleted, so do nothing.") };
@@ -108,9 +108,9 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
             return true;
         }
 
-        private bool AlreadyUpdated(RouteNode routeNode, RouteNode integratorRouteNode)
+        private bool AlreadyUpdated(RouteNode routeNode, RouteNode routeNodeShadowTable)
         {
-            return routeNode.MarkAsDeleted == integratorRouteNode.MarkAsDeleted && routeNode.GetGeoJsonCoordinate() == integratorRouteNode.GetGeoJsonCoordinate();
+            return routeNode.MarkAsDeleted == routeNodeShadowTable.MarkAsDeleted && routeNode.GetGeoJsonCoordinate() == routeNodeShadowTable.GetGeoJsonCoordinate();
         }
 
         private bool IsCreatedByApplication(RouteNode routeNode)

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Notifications/GeographicalAreaUpdated.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Notifications/GeographicalAreaUpdated.cs
@@ -1,16 +1,16 @@
 using MediatR;
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenFTTH.Events.Geo;
+using OpenFTTH.GDBIntegrator.Config;
 using OpenFTTH.GDBIntegrator.Producer;
 using OpenFTTH.GDBIntegrator.RouteNetwork;
 using OpenFTTH.GDBIntegrator.RouteNetwork.Factories;
-using OpenFTTH.GDBIntegrator.Config;
-using OpenFTTH.Events.Geo;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenFTTH.GDBIntegrator.Integrator.Notifications
 {
@@ -44,7 +44,7 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Notifications
 
         public async Task Handle(GeographicalAreaUpdated request, CancellationToken token)
         {
-            _logger.LogInformation($"Starting {nameof(GeographicalAreaUpdatedHandler)}");
+            _logger.LogDebug($"Starting {nameof(GeographicalAreaUpdatedHandler)}");
 
             var envelope = _envelopeFactory.Create(request.RouteNodes, request.RouteSegment);
             var envelopeInfo = new EnvelopeInfo(envelope.MinX, envelope.MaxX, envelope.MinY, envelope.MaxY);

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Notifications/RouteNodeLocationChanged.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Notifications/RouteNodeLocationChanged.cs
@@ -1,19 +1,19 @@
-using OpenFTTH.GDBIntegrator.RouteNetwork;
-using OpenFTTH.GDBIntegrator.Config;
-using OpenFTTH.GDBIntegrator.GeoDatabase;
-using OpenFTTH.Events.RouteNetwork;
-using OpenFTTH.GDBIntegrator.Integrator.Store;
-using OpenFTTH.GDBIntegrator.Integrator.Factories;
-using OpenFTTH.Events;
 using MediatR;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Linq;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NetTopologySuite.Geometries;
+using OpenFTTH.Events;
+using OpenFTTH.Events.RouteNetwork;
+using OpenFTTH.GDBIntegrator.Config;
+using OpenFTTH.GDBIntegrator.GeoDatabase;
+using OpenFTTH.GDBIntegrator.Integrator.Factories;
+using OpenFTTH.GDBIntegrator.Integrator.Store;
+using OpenFTTH.GDBIntegrator.RouteNetwork;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenFTTH.GDBIntegrator.Integrator.Notifications
 {


### PR DESCRIPTION
We do this to avoid rolling back to an invalid state in case of multiple events on the same element being executed one after each-other and one fails, and the before value is now invalid.