### PR TITLE
now checks shadow table if route element was created by gdb-integrator

### DIFF
--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/IGeoDatabase.cs
@@ -7,7 +7,9 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase
 {
     public interface IGeoDatabase
     {
+        Task<bool> RouteNodeInShadowTableExists(Guid mrid);
         Task<RouteNode> GetRouteNodeShadowTable(Guid mrid, bool includeDeleted = false);
+        Task<bool> RouteSegmentInShadowTableExists(Guid mrid);
         Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool includeDeleted = false);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(RouteSegment routeSegment);
         Task<List<RouteNode>> GetIntersectingStartRouteNodes(byte[] coord);

--- a/src/OpenFTTH.GDBIntegrator.GeoDatabase/Postgres/Postgis.cs
+++ b/src/OpenFTTH.GDBIntegrator.GeoDatabase/Postgres/Postgis.cs
@@ -67,6 +67,13 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase.Postgres
             await DisposeConnection();
         }
 
+        public async Task<bool> RouteNodeInShadowTableExists(Guid mrid)
+        {
+            var connection = GetNpgsqlConnection();
+            var query = @"SELECT exists(SELECT 1 FROM route_network_integrator.route_node WHERE mrid = @mrid)";
+            return await connection.QueryFirstAsync<bool>(query, new { mrid });
+        }
+
         public async Task<RouteNode> GetRouteNodeShadowTable(Guid mrid, bool includeDeleted = false)
         {
             var connection = GetNpgsqlConnection();
@@ -144,6 +151,13 @@ namespace OpenFTTH.GDBIntegrator.GeoDatabase.Postgres
                 });
 
             return routeNodes.FirstOrDefault();
+        }
+
+        public async Task<bool> RouteSegmentInShadowTableExists(Guid mrid)
+        {
+            var connection = GetNpgsqlConnection();
+            var query = @"SELECT exists(SELECT 1 FROM route_network_integrator.route_segment WHERE mrid = @mrid)";
+            return await connection.QueryFirstAsync<bool>(query, new { mrid });
         }
 
         public async Task<RouteSegment> GetRouteSegmentShadowTable(Guid mrid, bool includeDeleted = false)

--- a/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentCommandFactory.cs
+++ b/src/OpenFTTH.GDBIntegrator.Integrator/Factories/RouteSegmentCommandFactory.cs
@@ -107,8 +107,11 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
             if (routeSegment is null)
                 throw new ArgumentNullException($"Parameter {nameof(routeSegment)} must not be null");
 
-            if (IsCreatedByApplication(routeSegment))
+            // If we find the route segment is in the shadow table, it means that it was created by the application and we therefore do nothing.
+            if (await _geoDatabase.RouteSegmentInShadowTableExists(routeSegment.Mrid))
+            {
                 return new List<INotification>();
+            }
 
             // Update integrator "shadow table" with the used digitized segment
             await _geoDatabase.InsertRouteSegmentShadowTable(routeSegment);
@@ -162,11 +165,6 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Factories
         private bool AlreadyUpdated(RouteSegment routeSegment, RouteSegment shadowTableRouteSegment)
         {
             return routeSegment.MarkAsDeleted == shadowTableRouteSegment.MarkAsDeleted && routeSegment.GetGeoJsonCoordinate() == shadowTableRouteSegment.GetGeoJsonCoordinate();
-        }
-
-        private bool IsCreatedByApplication(RouteSegment routeSegment)
-        {
-            return routeSegment.ApplicationName == _applicationSettings.ApplicationName;
         }
 
         private RouteSegmentDeleted CreateRouteSegmentDeleted(RouteSegment routeSegment)

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteNodeCommandFactoryTest.cs
@@ -39,13 +39,14 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var applicationSetting = A.Fake<IOptions<ApplicationSetting>>();
             var geoDatabase = A.Fake<IGeoDatabase>();
             var routeNodeValidator = A.Fake<IRouteNodeValidator>();
+            var routeNodeMrid = Guid.NewGuid();
 
-            A.CallTo(() => applicationSetting.Value).Returns(
-                new ApplicationSetting { ApplicationName = "GDB_INTEGRATOR" });
+            A.CallTo(() => geoDatabase.RouteNodeInShadowTableExists(routeNodeMrid))
+                .Returns(true);
 
             var factory = new RouteNodeCommandFactory(applicationSetting, geoDatabase, routeNodeValidator);
 
-            var routeNode = new RouteNode(Guid.Empty, null, Guid.Empty, String.Empty, "GDB_INTEGRATOR");
+            var routeNode = new RouteNode(routeNodeMrid, null, Guid.Empty, String.Empty, "GDB_INTEGRATOR");
             var result = (DoNothing)((await factory.CreateDigitizedEvent(routeNode)).First());
 
             result.Should().BeOfType<DoNothing>();

--- a/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentCommandFactoryTest.cs
+++ b/test/OpenFTTH.GDBIntegrator.Integrator.Tests/Factories/RouteSegmentCommandFactoryTest.cs
@@ -43,10 +43,10 @@ namespace OpenFTTH.GDBIntegrator.Integrator.Tests.Factories
             var routeSegmentValidator = A.Fake<IRouteSegmentValidator>();
             var geoDatabase = A.Fake<IGeoDatabase>();
             var routeNodeFactory = A.Fake<IRouteNodeFactory>();
-            var routeSegment = new RouteSegment { ApplicationName = "GDB_INTEGRATOR" };
+            var routeSegment = new RouteSegment { Mrid = Guid.NewGuid(), ApplicationName = "GDB_INTEGRATOR" };
 
-            A.CallTo(() => applicationSettings.Value)
-                .Returns(new ApplicationSetting { ApplicationName = "GDB_INTEGRATOR" });
+            A.CallTo(() => geoDatabase.RouteSegmentInShadowTableExists(routeSegment.Mrid))
+                .Returns(true);
 
             var factory = new RouteSegmentCommandFactory(applicationSettings, routeSegmentValidator, geoDatabase, routeNodeFactory);
 


### PR DESCRIPTION
We have had issues where users copy-paste the geometry from a GIS solution, example is QGIS. The problem is that the user also copies the `ApplicationName` field, and that results in the GDB integrator thinking that it was created by itself, and ignores the event.

Now we have switched to checking the shadow table if the route elements exists, if it does we have created it, otherwise it is a new digitized event by the user.